### PR TITLE
Update to experimental `Hexa.NET.ImGui` bindings

### DIFF
--- a/src/core/Fahrenheit.csproj
+++ b/src/core/Fahrenheit.csproj
@@ -62,7 +62,7 @@
     <ItemGroup>
         <PackageReference Include="Blake3" Version="3.0.2" />
         <PackageReference Include="Hexa.NET.DirectXTex" Version="2.0.4" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.0.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.1.0-experimental" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/Fahrenheit.csproj
+++ b/src/core/Fahrenheit.csproj
@@ -62,7 +62,7 @@
     <ItemGroup>
         <PackageReference Include="Blake3" Version="3.0.2" />
         <PackageReference Include="Hexa.NET.DirectXTex" Version="2.0.4" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="1.0.18" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.0.0-experimental" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/resload.cs
+++ b/src/core/resload.cs
@@ -118,7 +118,7 @@ public sealed record FhTexture(string path, FhTextureType type) {
              * Testing the return value of Release is meaningless because it is not guaranteed to be precise.
              * If you believe you're leaking textures, turn on the D3D debug layer instead.
              */
-            ((ID3D11ShaderResourceView*)(void*)_tex_ref.GetTexID())->Release();
+            ((ID3D11ShaderResourceView*)(void*)_tex_ref.TexID)->Release();
         }
 
         _tex_ref      = default;

--- a/src/eedit/Fahrenheit.Tools.EEdit.csproj
+++ b/src/eedit/Fahrenheit.Tools.EEdit.csproj
@@ -36,8 +36,8 @@
     <!-- PACKAGE REFERENCES -->
     <ItemGroup>
         <PackageReference Include="NativeFileDialogCore" Version="1.0.3" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="1.0.18" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="1.0.18" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.0.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="3.0.0-experimental" />
         <PackageReference Include="Hexa.NET.SDL3" Version="1.2.11" />
         <PackageReference Include="Hexa.NET.OpenGL3" Version="1.1.0" />
     </ItemGroup>

--- a/src/eedit/Fahrenheit.Tools.EEdit.csproj
+++ b/src/eedit/Fahrenheit.Tools.EEdit.csproj
@@ -36,8 +36,8 @@
     <!-- PACKAGE REFERENCES -->
     <ItemGroup>
         <PackageReference Include="NativeFileDialogCore" Version="1.0.3" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.0.0-experimental" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="3.0.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.1.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="3.1.0-experimental" />
         <PackageReference Include="Hexa.NET.SDL3" Version="1.2.11" />
         <PackageReference Include="Hexa.NET.OpenGL3" Version="1.1.0" />
     </ItemGroup>

--- a/src/modmgr/Fahrenheit.Tools.ModManager.csproj
+++ b/src/modmgr/Fahrenheit.Tools.ModManager.csproj
@@ -40,8 +40,8 @@
 
     <!-- EXTERNAL PROJECT REFS -->
     <ItemGroup>
-        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.0.0-experimental" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="3.0.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.1.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="3.1.0-experimental" />
         <PackageReference Include="Hexa.NET.SDL3" Version="1.2.11" />
         <PackageReference Include="Hexa.NET.OpenGL3" Version="1.1.0" />
     </ItemGroup>

--- a/src/modmgr/Fahrenheit.Tools.ModManager.csproj
+++ b/src/modmgr/Fahrenheit.Tools.ModManager.csproj
@@ -40,8 +40,8 @@
 
     <!-- EXTERNAL PROJECT REFS -->
     <ItemGroup>
-        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="1.0.18" />
-        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="1.0.18" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends" Version="3.0.0-experimental" />
+        <PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="3.0.0-experimental" />
         <PackageReference Include="Hexa.NET.SDL3" Version="1.2.11" />
         <PackageReference Include="Hexa.NET.OpenGL3" Version="1.1.0" />
     </ItemGroup>

--- a/src/runtime/imgui.cs
+++ b/src/runtime/imgui.cs
@@ -100,7 +100,7 @@ public unsafe sealed class FhImguiModule : FhModule, IFhPlatformUser {
 
         ImGuiImplWin32.SetCurrentContext(ctx);
         ImGuiImplD3D11.SetCurrentContext(ctx);
-        ImGuiImplWin32.Init(_hWnd);
+        ImGuiImplWin32.Init((nint)_hWnd);
         ImGuiImplD3D11.Init(hexa_p_device, hexa_p_device_ctx);
 
         /* [fkelava 20/06/26 17:38]


### PR DESCRIPTION
The maintainer is soliciting feedback for an experimental release that would update us to ImGui 1.92.9b. The inner code generator is changed. If we want this to be properly tested by `alpha12`, it should merge so we're actively dogfooding it when developing.