### PR TITLE
Stage1: Change working directory preemptively

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ To install/test your development build:
 and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).
 
 ## Compatibility notes
+Do not run either the game or Fahrenheit as an administrator. This does not work and is strictly unsupported. 
+If you see a UAC icon (little shield) over your game executable, right click it, go to `Properties > Compatibility`, 
+and ensure `Run this program as an administrator` is **not checked**.
 
 Fahrenheit comes with an integrated external file loader. If you simultaneously use ffgriever's
 [External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader), the resulting behavior is undefined.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ To install/test your development build:
 and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).
 
 ## Compatibility notes
-Fahrenheit is incompatible with ffgriever's
-[External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader).
-Fahrenheit comes with an integrated external file loader. Existing file-based mods must be converted to Fahrenheit format.
+
+Fahrenheit comes with an integrated external file loader. If you simultaneously use ffgriever's
+[External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader), the resulting behavior is undefined.
 
 If you use [Untitled Project X](https://github.com/Kaldaien/UnX) with Fahrenheit,
 you **must** patch the game executable to be large-address-aware (apply the "4GB patch"). If you don't, you will run out of memory at boot.

--- a/src/core/pathmgr.cs
+++ b/src/core/pathmgr.cs
@@ -46,14 +46,14 @@ internal sealed class FhFinder {
 
     internal FhFinder() {
         // If this somehow throws, we really have no business executing at all.
-        string cwd_parent = Directory.GetParent(Directory.GetCurrentDirectory())?.FullName!;
+        string cwd = Directory.GetCurrentDirectory();
 
-        Binaries = Directory.CreateDirectory(Path.Join(cwd_parent, _dirname_bin));
-        Config   = Directory.CreateDirectory(Path.Join(cwd_parent, _dirname_cfg));
-        Mods     = Directory.CreateDirectory(Path.Join(cwd_parent, _dirname_mods));
-        Logs     = Directory.CreateDirectory(Path.Join(cwd_parent, _dirname_logs, FhUtil.get_timestamp_string()));
-        State    = Directory.CreateDirectory(Path.Join(cwd_parent, _dirname_state));
-        Saves    = Directory.CreateDirectory(Path.Join(cwd_parent, _dirname_saves));
+        Binaries = Directory.CreateDirectory(Path.Join(cwd, "fahrenheit", _dirname_bin));
+        Config   = Directory.CreateDirectory(Path.Join(cwd, "fahrenheit", _dirname_cfg));
+        Mods     = Directory.CreateDirectory(Path.Join(cwd, "fahrenheit", _dirname_mods));
+        Logs     = Directory.CreateDirectory(Path.Join(cwd, "fahrenheit", _dirname_logs, FhUtil.get_timestamp_string()));
+        State    = Directory.CreateDirectory(Path.Join(cwd, "fahrenheit", _dirname_state));
+        Saves    = Directory.CreateDirectory(Path.Join(cwd, "fahrenheit", _dirname_saves));
     }
 
     /// <summary>

--- a/src/stage1/Fahrenheit.Loader.Stage1.vcxproj
+++ b/src/stage1/Fahrenheit.Loader.Stage1.vcxproj
@@ -156,6 +156,7 @@
     <ClInclude Include="inc\resource.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\eh.cpp" />
     <ClCompile Include="src\main.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/stage1/Fahrenheit.Loader.Stage1.vcxproj.filters
+++ b/src/stage1/Fahrenheit.Loader.Stage1.vcxproj.filters
@@ -26,6 +26,9 @@
     <ClCompile Include="src\main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\eh.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="inc\fhstage1.rc">

--- a/src/stage1/inc/fhstage1.h
+++ b/src/stage1/inc/fhstage1.h
@@ -11,27 +11,18 @@
 
 #pragma once
 #pragma comment(lib, "dbghelp.lib")
+#pragma comment(lib, "pathcch.lib")
 
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
 #include <iostream>
-#include <fstream>
-#include <direct.h>
 
+// Win32 API
 #include <windows.h>
-#include <winternl.h>
 #include <DbgHelp.h>
+#include <PathCch.h>
 
-#define STR(s) L ## s
-#define CH(c)  L ## c
-#define DIR_SEPARATOR L'\\'
-
- // .NET hosting headers
+// .NET hosting headers
 #include <nethost.h>
 #include <coreclr_delegates.h>
 #include <hostfxr.h>

--- a/src/stage1/src/eh.cpp
+++ b/src/stage1/src/eh.cpp
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+// This file is part of Fahrenheit, © 2023-2026 The Fahrenheit contributors.
+// It is licensed to you under the GNU Lesser General Public License, version 3.0 or later. See COPYING, COPYING.LESSER.
+
+/* [fkelava 29/5/23 18:15]
+ * See THIRD-PARTY-NOTICES.
+ *
+ * For the exception handling, see:
+ * - http://code.aaronballman.com/minidumper/MiniDump.cpp
+ * - https://github.com/folgerwang/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/Windows/WindowsPlatformCrashContext.cpp
+ */
+
+#include "fhstage1.h"
+
+using eh_fn = LONG(*)(EXCEPTION_POINTERS*);
+
+eh_fn g_fnptr_eh_original = nullptr; // A function pointer to the game's original SEH filter.
+
+DWORD               g_eh_thread_faulting_id; // The ID of the thread that threw a structured exception.
+DWORD               g_eh_thread_handler_id;  // The ID of the thread handling structured exceptions.
+HANDLE              g_eh_thread_handler;     // The handle to the thread handling structured exceptions.
+EXCEPTION_POINTERS* g_eh_exception_ptr;      // A pointer to the exception bringing the process down.
+
+/*
+ * Filters a core dump to exclude objects which we do not want to record.
+ */
+
+static BOOL CALLBACK stage1_eh_filter_dump(
+          PVOID                     ptr_callback_param,
+    const PMINIDUMP_CALLBACK_INPUT  ptr_callback_input,
+          PMINIDUMP_CALLBACK_OUTPUT ptr_callback_output) {
+    if (!ptr_callback_input || !ptr_callback_output) return FALSE;
+
+    switch (ptr_callback_input->CallbackType) {
+        case CancelCallback:
+            return FALSE;
+
+        case IncludeThreadCallback: {
+            // Exclude the thread which writes the minidump.
+            return ptr_callback_input->IncludeThread.ThreadId != g_eh_thread_handler_id;
+        } break;
+    }
+
+    return TRUE;
+}
+
+/*
+ * Writes a customized core dump.
+ */
+
+static DWORD CALLBACK stage1_eh_create_dump(LPVOID ptr_thread_parameter) {
+    HANDLE hFile = CreateFileW(
+        L"crash_dump.dmp",
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        nullptr,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+
+    if (hFile == NULL || hFile == INVALID_HANDLE_VALUE) {
+        std::wcerr << "Failed to open a file to write the core dump to." << std::endl;
+        return 1;
+    }
+
+    HANDLE        hProcess  = GetCurrentProcess();
+    DWORD         ProcessId = GetProcessId(hProcess);
+    MINIDUMP_TYPE DumpType  = (MINIDUMP_TYPE)(
+                              MiniDumpNormal
+                            | MiniDumpWithDataSegs
+                            | MiniDumpWithHandleData
+                            | MiniDumpWithFullMemoryInfo
+                            | MiniDumpWithThreadInfo
+                            | MiniDumpWithProcessThreadData
+                            | MiniDumpWithUnloadedModules);
+
+    /* [fkelava 11/06/26 21:24]
+     * For ClientPointers:
+     * https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception_information#members
+     * > If you are accessing local memory (in the calling process) you should not set this member to TRUE.
+     */
+    MINIDUMP_EXCEPTION_INFORMATION mdei = { 0 };
+    mdei.ThreadId          = g_eh_thread_faulting_id;
+    mdei.ExceptionPointers = g_eh_exception_ptr;
+    mdei.ClientPointers    = FALSE;
+
+    MINIDUMP_CALLBACK_INFORMATION mci = { 0 };
+    mci.CallbackRoutine = (MINIDUMP_CALLBACK_ROUTINE)stage1_eh_filter_dump;
+    mci.CallbackParam   = nullptr;
+
+    PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam = g_eh_exception_ptr != nullptr ? &mdei : nullptr;
+    PMINIDUMP_CALLBACK_INFORMATION  CallbackParam  = &mci;
+
+    std::wcerr << "Dumping process core. Please wait." << std::endl;
+
+    BOOL rv = MiniDumpWriteDump(
+        hProcess,
+        ProcessId,
+        hFile,
+        DumpType,
+        ExceptionParam,
+        nullptr,
+        CallbackParam);
+
+    if (!rv) {
+        std::wcerr << "Failed to capture a core dump." << std::endl;
+        return 1;
+    }
+
+    CloseHandle(hFile);
+    return 0;
+}
+
+/* [fkelava 11/06/26 16:27]
+ * An exception handler which behaves the same as the game's,
+ * except that it _unconditionally_ emits a customized core dump.
+ *
+ * See:
+ * - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
+ * - https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-unhandledexceptionfilter
+ * - FFX.exe+226A90
+ * - https://www.debuginfo.com/examples/src/effminidumps/MiniDump.cpp
+ */
+
+static LONG WINAPI stage1_eh(EXCEPTION_POINTERS* ptr_exception_info) {
+    g_eh_exception_ptr      = ptr_exception_info;
+    g_eh_thread_faulting_id = GetCurrentThreadId();
+
+    ::ResumeThread       (g_eh_thread_handler);
+    ::WaitForSingleObject(g_eh_thread_handler, INFINITE);
+    ::CloseHandle        (g_eh_thread_handler);
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+/* [fkelava 11/06/26 16:27]
+ * Ignores the game's attempt to install its own exception handler.
+ */
+
+static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI stage1_eh_set_filter(LPTOP_LEVEL_EXCEPTION_FILTER fnptr_exception_filter) {
+    return &stage1_eh;
+}
+
+/* [fkelava 11/06/26 16:27]
+ * If necessary, replaces the game's EH filter with a Stage1 custom one.
+ */
+
+BOOL stage1_eh_install(LPBYTE ptr_main_module) {
+    char_t exe_full_name_buf[MAX_PATH];
+    auto size = ::GetModuleFileNameW(NULL, exe_full_name_buf, sizeof(exe_full_name_buf) / sizeof(char_t));
+
+    std::basic_string<char_t> exe_full_name       = exe_full_name_buf;
+    size_t                    exe_name_dirsep_pos = exe_full_name.find_last_of(L'\\') + 1;
+
+    if (exe_name_dirsep_pos == std::basic_string<char_t>::npos) {
+        std::wcerr << "The path to the target binary is invalid." << std::endl;
+        return FALSE;
+    }
+
+    std::basic_string<char_t> exe_name = exe_full_name.substr(exe_name_dirsep_pos, exe_full_name.length());
+
+    // This can be generalized for other games in the future.
+    if (exe_name.compare(L"FFX.exe")   != 0
+    &&  exe_name.compare(L"FFX-2.exe") != 0)
+        return TRUE;
+
+    g_eh_thread_handler = ::CreateThread(
+        nullptr,
+        0,
+        stage1_eh_create_dump,
+        nullptr,
+        CREATE_SUSPENDED,
+        &g_eh_thread_handler_id);
+
+    if (g_eh_thread_handler == nullptr || g_eh_thread_handler == INVALID_HANDLE_VALUE) {
+        std::wcerr << "Failed to create EH thread for " << exe_name << std::endl;
+        return FALSE;
+    }
+
+    ::SetThreadDescription(g_eh_thread_handler, L"Fahrenheit EH");
+    SetUnhandledExceptionFilter(&stage1_eh);
+
+    if (MH_CreateHookApi(L"kernel32.dll", "SetUnhandledExceptionFilter", &stage1_eh_set_filter, reinterpret_cast<void**>(&g_fnptr_eh_original)) != MH_OK
+    ||  MH_EnableHook   (&SetUnhandledExceptionFilter)                                                                                          != MH_OK) {
+        std::wcerr << "Failed to install EH hook for " << exe_name << std::endl;
+        return FALSE;
+    }
+
+    std::wcout << "Installed EH hook for " << exe_name << std::endl;
+    return TRUE;
+}

--- a/src/stage1/src/main.cpp
+++ b/src/stage1/src/main.cpp
@@ -9,59 +9,51 @@
  * See THIRD-PARTY-NOTICES.
  *
  * For the HostFXR bits, see https://github.com/dotnet/samples/blob/main/core/hosting/src/NativeHost/nativehost.cpp.
- * For the exception handling, see:
- * - http://code.aaronballman.com/minidumper/MiniDump.cpp
- * - https://github.com/folgerwang/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/Windows/WindowsPlatformCrashContext.cpp
  */
 
 #include "fhstage1.h"
 
-// Function pointer to managed delegate with our own signature
-typedef void (CORECLR_DELEGATE_CALLTYPE* fh_init)();
+typedef void (CORECLR_DELEGATE_CALLTYPE* fh_init)(); // Function pointer to managed delegate with our own signature
 
-using string_t = std::basic_string<char_t>;
-using main_fn  = int(*)(void);
-using eh_fn    = LONG(*)(EXCEPTION_POINTERS*);
+using main_fn = int(*)(void);
 
-// Globals to hold original and detour addresses of program entrypoint and SEH filter
-main_fn g_fnptr_main_original = nullptr;
-main_fn g_fnptr_main_target   = nullptr;
-eh_fn   g_fnptr_eh_original   = nullptr;
+main_fn g_fnptr_main_original = nullptr; // A function pointer to the game's original entrypoint.
+main_fn g_fnptr_main_target   = nullptr; // A function pointer to our modified Stage 1 entrypoint.
 
-// Globals for EH override
-DWORD               g_eh_thread_faulting_id;
-DWORD               g_eh_thread_handler_id;
-HANDLE              g_eh_thread_handler;
-EXCEPTION_POINTERS* g_eh_exception_ptr;
+char_t path_target_buf[MAX_PATH]; // The path to the binary we're being loaded into.
+char_t path_fh_buf    [MAX_PATH]; // The path to the `fahrenheit/bin` directory we were started in.
 
-// Globals to hold hostfxr exports
 hostfxr_initialize_for_runtime_config_fn g_fnptr_hostfxr_init;
 hostfxr_set_runtime_property_value_fn    g_fnptr_hostfxr_set_runtime_property;
 hostfxr_get_runtime_delegate_fn          g_fnptr_hostfxr_get_delegate;
 hostfxr_close_fn                         g_fnptr_hostfxr_close;
 
-// Using the nethost library, discover the location of hostfxr and get exports
-static bool load_hostfxr() {
-    // Pre-allocate a large buffer for the path to hostfxr
-    char_t buffer[MAX_PATH];
-    size_t buffer_size = sizeof(buffer) / sizeof(char_t);
+BOOL stage1_eh_install(LPBYTE ptr_main_module); // Forward declaration of EH installer function
 
-    int rc = get_hostfxr_path(buffer, &buffer_size, nullptr);
+/*
+ * Uses the `nethost` library to discover the location of the .NET hosting library,
+ * `hostfxr`, and obtains the necessary function pointers from it.
+ */
+
+static bool load_hostfxr() {
+    char_t path_hostfxr_buf[MAX_PATH];
+    size_t path_hostfxr_size = sizeof(path_hostfxr_buf) / sizeof(char_t);
+
+    int rc = get_hostfxr_path(path_hostfxr_buf, &path_hostfxr_size, nullptr);
     if (rc != 0) {
         std::wcerr << "get_hostfxr_path() failed, error code: " << rc << std::endl;
         return false;
     }
 
-    // Load hostfxr and get desired exports
-    HMODULE lib = ::LoadLibraryW(buffer);
+    HMODULE lib_hostfxr = ::LoadLibraryW(path_hostfxr_buf);
 
-    if (lib == nullptr)
+    if (lib_hostfxr == nullptr)
         return FALSE;
 
-    g_fnptr_hostfxr_init                 = (hostfxr_initialize_for_runtime_config_fn)::GetProcAddress(lib, "hostfxr_initialize_for_runtime_config");
-    g_fnptr_hostfxr_set_runtime_property = (hostfxr_set_runtime_property_value_fn)   ::GetProcAddress(lib, "hostfxr_set_runtime_property_value");
-    g_fnptr_hostfxr_get_delegate         = (hostfxr_get_runtime_delegate_fn)         ::GetProcAddress(lib, "hostfxr_get_runtime_delegate");
-    g_fnptr_hostfxr_close                = (hostfxr_close_fn)                        ::GetProcAddress(lib, "hostfxr_close");
+    g_fnptr_hostfxr_init                 = (hostfxr_initialize_for_runtime_config_fn)::GetProcAddress(lib_hostfxr, "hostfxr_initialize_for_runtime_config");
+    g_fnptr_hostfxr_set_runtime_property = (hostfxr_set_runtime_property_value_fn)   ::GetProcAddress(lib_hostfxr, "hostfxr_set_runtime_property_value");
+    g_fnptr_hostfxr_get_delegate         = (hostfxr_get_runtime_delegate_fn)         ::GetProcAddress(lib_hostfxr, "hostfxr_get_runtime_delegate");
+    g_fnptr_hostfxr_close                = (hostfxr_close_fn)                        ::GetProcAddress(lib_hostfxr, "hostfxr_close");
 
     return g_fnptr_hostfxr_init
         && g_fnptr_hostfxr_set_runtime_property
@@ -69,167 +61,9 @@ static bool load_hostfxr() {
         && g_fnptr_hostfxr_close;
 }
 
-/* [fkelava 11/06/26 16:27]
- * An exception handler which behaves the same as the game's,
- * except that it _unconditionally_ emits a customized core dump.
- *
- * See:
- * - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
- * - https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-unhandledexceptionfilter
- * - FFX.exe+226A90
- * - https://www.debuginfo.com/examples/src/effminidumps/MiniDump.cpp
- */
-
-// Filters the core dump to exclude objects which we do not want to record.
-static BOOL CALLBACK stage1_eh_filter_dump(
-          PVOID                     ptr_callback_param,
-    const PMINIDUMP_CALLBACK_INPUT  ptr_callback_input,
-          PMINIDUMP_CALLBACK_OUTPUT ptr_callback_output) {
-    if (!ptr_callback_input || !ptr_callback_output) return FALSE;
-
-    switch (ptr_callback_input->CallbackType) {
-        case CancelCallback:
-            return FALSE;
-
-        case IncludeThreadCallback: {
-            // Exclude the thread which writes the minidump.
-            return ptr_callback_input->IncludeThread.ThreadId != g_eh_thread_handler_id;
-        } break;
-    }
-
-    return TRUE;
-}
-
-// Writes a customized core dump.
-static DWORD CALLBACK stage1_eh_create_dump(LPVOID ptr_thread_parameter) {
-    HANDLE hFile = CreateFileW(
-        L"crash_dump.dmp",
-        GENERIC_READ | GENERIC_WRITE,
-        0,
-        nullptr,
-        CREATE_ALWAYS,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr);
-
-    if (hFile == NULL || hFile == INVALID_HANDLE_VALUE) {
-        std::wcerr << "Failed to open a file to write the core dump to." << std::endl;
-        return 1;
-    }
-
-    HANDLE        hProcess  = GetCurrentProcess();
-    DWORD         ProcessId = GetProcessId(hProcess);
-    MINIDUMP_TYPE DumpType  = (MINIDUMP_TYPE)(
-                              MiniDumpNormal
-                            | MiniDumpWithDataSegs
-                            | MiniDumpWithHandleData
-                            | MiniDumpWithFullMemoryInfo
-                            | MiniDumpWithThreadInfo
-                            | MiniDumpWithProcessThreadData
-                            | MiniDumpWithUnloadedModules);
-
-    /* [fkelava 11/06/26 21:24]
-     * For ClientPointers:
-     * https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception_information#members
-     * > If you are accessing local memory (in the calling process) you should not set this member to TRUE.
-     */
-    MINIDUMP_EXCEPTION_INFORMATION mdei = { 0 };
-    mdei.ThreadId          = g_eh_thread_faulting_id;
-    mdei.ExceptionPointers = g_eh_exception_ptr;
-    mdei.ClientPointers    = FALSE;
-
-    MINIDUMP_CALLBACK_INFORMATION mci = { 0 };
-    mci.CallbackRoutine = (MINIDUMP_CALLBACK_ROUTINE)stage1_eh_filter_dump;
-    mci.CallbackParam   = nullptr;
-
-    PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam = g_eh_exception_ptr != nullptr ? &mdei : nullptr;
-    PMINIDUMP_CALLBACK_INFORMATION  CallbackParam  = &mci;
-
-    std::wcerr << "Dumping process core. Please wait." << std::endl;
-
-    BOOL rv = MiniDumpWriteDump(
-        hProcess,
-        ProcessId,
-        hFile,
-        DumpType,
-        ExceptionParam,
-        nullptr,
-        CallbackParam);
-
-    if (!rv) {
-        std::wcerr << "Failed to capture a core dump." << std::endl;
-        return 1;
-    }
-
-    CloseHandle(hFile);
-    return 0;
-}
-
-// The Stage1 exception handler.
-static LONG WINAPI stage1_eh(EXCEPTION_POINTERS* ptr_exception_info) {
-    g_eh_exception_ptr      = ptr_exception_info;
-    g_eh_thread_faulting_id = GetCurrentThreadId();
-
-    ::ResumeThread       (g_eh_thread_handler);
-    ::WaitForSingleObject(g_eh_thread_handler, INFINITE);
-    ::CloseHandle        (g_eh_thread_handler);
-
-    return EXCEPTION_CONTINUE_SEARCH;
-}
-
-// Ignores the game's attempt to install its own exception handler.
-static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI stage1_eh_set_filter(LPTOP_LEVEL_EXCEPTION_FILTER fnptr_exception_filter) {
-    return &stage1_eh;
-}
-
-// If necessary, replaces the game's EH filter with a Stage1 custom one.
-static BOOL stage1_eh_install(LPBYTE ptr_main_module) {
-    char_t exe_full_name_buf[MAX_PATH];
-    auto size = ::GetModuleFileNameW(NULL, exe_full_name_buf, sizeof(exe_full_name_buf) / sizeof(char_t));
-
-    string_t exe_full_name       = exe_full_name_buf;
-    size_t   exe_name_dirsep_pos = exe_full_name.find_last_of(DIR_SEPARATOR) + 1;
-
-    if (exe_name_dirsep_pos == string_t::npos) {
-        std::wcerr << "The path to the target binary is invalid." << std::endl;
-        return FALSE;
-    }
-
-    string_t exe_name = exe_full_name.substr(exe_name_dirsep_pos, exe_full_name.length());
-
-    // This can be generalized for other games in the future.
-    if (exe_name.compare(L"FFX.exe")   != 0
-    &&  exe_name.compare(L"FFX-2.exe") != 0)
-        return TRUE;
-
-    g_eh_thread_handler = ::CreateThread(
-        nullptr,
-        0,
-        stage1_eh_create_dump,
-        nullptr,
-        CREATE_SUSPENDED,
-        &g_eh_thread_handler_id);
-
-    if (g_eh_thread_handler == nullptr || g_eh_thread_handler == INVALID_HANDLE_VALUE) {
-        std::wcerr << "Failed to create EH thread for " << exe_name << std::endl;
-        return FALSE;
-    }
-
-    ::SetThreadDescription(g_eh_thread_handler, L"Fahrenheit EH");
-    SetUnhandledExceptionFilter(&stage1_eh);
-
-    if (MH_CreateHookApi(L"kernel32.dll", "SetUnhandledExceptionFilter", &stage1_eh_set_filter, reinterpret_cast<void**>(&g_fnptr_eh_original)) != MH_OK
-    ||  MH_EnableHook   (&SetUnhandledExceptionFilter)                                                                                          != MH_OK) {
-        std::wcerr << "Failed to install EH hook for " << exe_name << std::endl;
-        return FALSE;
-    }
-
-    std::wcout << "Installed EH hook for " << exe_name << std::endl;
-    return TRUE;
-}
-
 // Runs before the program's own entrypoint, setting up Fahrenheit.
 static int stage1_main(void) {
-    // STEP 1:
+    // STEP 4:
     // Attach to the Stage0 console and forward stdout/stderr to it.
     if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
         std::wcerr << "Failed to attach to the Stage0 console." << std::endl;
@@ -245,7 +79,7 @@ static int stage1_main(void) {
         exit(EXIT_FAILURE);
     }
 
-    // STEP 2:
+    // STEP 5:
     // If supported, install an EH override which allows us to capture
     // a customized core dump for easier debugging.
     HMODULE hMainModule = GetModuleHandleW(nullptr);
@@ -256,48 +90,17 @@ static int stage1_main(void) {
         exit(EXIT_FAILURE);
     }
 
-    // STEP 3:
-    // Determine the current working directory and the location
-    // of the executable being launched, to which we will swap
-    // the working directory later.
-    char_t host_path_buf[MAX_PATH]; // where is the game?
-    char_t cwd_path_buf [MAX_PATH]; // where are _we_?
-
-    auto size     = ::GetModuleFileNameW  (NULL, host_path_buf, sizeof(host_path_buf) / sizeof(char_t));
-    auto cwd_size = ::GetCurrentDirectoryW(sizeof(cwd_path_buf) / sizeof(char_t), cwd_path_buf);
-
-    if (size == 0) {
-        std::wcerr << "GetModuleFileName() failed." << std::endl;
-        exit(GetLastError());
-    }
-
-    if (cwd_size == 0) {
-        std::wcerr << "GetCurrentDirectory() failed." << std::endl;
-        exit(GetLastError());
-    }
-
-    string_t host_path = host_path_buf;
-    string_t cwd_path  = cwd_path_buf;
-
-    // STEP 4:
+    // STEP 6:
     // Declare the name, type, and location of the bootstrap method to invoke.
-    const string_t clrhost_config_path = cwd_path + STR("\\fh.runtimeconfig.json");
-    const string_t clrhost_lib_path    = cwd_path + STR("\\fh.dll");
-    const char_t*  clrhost_type        = STR("Fahrenheit.FhEnvironment, fh");
-    const char_t*  clrhost_init_method = STR("boot");
+    std::basic_string<char_t> path_cwd = path_fh_buf;
 
-    auto host_dirsep_pos = host_path.find_last_of(DIR_SEPARATOR);
+    const std::basic_string<char_t> path_fh_runtimeconfig = path_cwd + L"\\fh.runtimeconfig.json";
+    const std::basic_string<char_t> path_fh_dll           = path_cwd + L"\\fh.dll";
 
-    if (host_dirsep_pos == string_t::npos) {
-        std::wcerr << "The path to the target binary is invalid." << std::endl;
-        exit(EXIT_FAILURE);
-    }
+    const char_t* fh_init_type   = L"Fahrenheit.FhEnvironment, fh";
+    const char_t* fh_init_method = L"boot";
 
-    std::wcout << "Stage 1 Loader executing for: " << host_path << std::endl;
-
-    host_path = host_path.substr(0, host_dirsep_pos + 1);
-
-    // STEP 5:
+    // STEP 7:
     // Load HostFxr. This library will locate the .NET runtime for us.
     if (!load_hostfxr()) {
         std::wcerr << "hostfxr: failed to load" << std::endl;
@@ -305,13 +108,13 @@ static int stage1_main(void) {
         exit(EXIT_FAILURE);
     }
 
-    // STEP 6:
+    // STEP 8:
     // Initialize and start the .NET runtime.
     void*          ptr_hostfxr_load_assembly        = nullptr;
     void*          ptr_hostfxr_get_function_pointer = nullptr;
     hostfxr_handle cxt                              = nullptr;
 
-    int rc = g_fnptr_hostfxr_init(clrhost_config_path.c_str(), nullptr, &cxt);
+    int rc = g_fnptr_hostfxr_init(path_fh_runtimeconfig.c_str(), nullptr, &cxt);
     if (rc != 0 || cxt == nullptr) {
         std::wcerr << "hostfxr: initialize_for_runtime_config() failed" << std::endl;
         std::wcerr << "This is an uncommon error. Please contact the Fahrenheit developers at https://github.com/fahrenheit-crew/fahrenheit." << std::endl;
@@ -320,12 +123,12 @@ static int stage1_main(void) {
         exit(rc);
     }
 
-    // STEP 7:
+    // STEP 9:
     // Set up AppContext.BaseDirectory so we can use it to find runtime dependencies.
     rc = g_fnptr_hostfxr_set_runtime_property(
         cxt,
         L"APP_CONTEXT_BASE_DIRECTORY",
-        cwd_path.c_str());
+        path_cwd.c_str());
 
     if (rc != 0) {
         std::wcerr << "hostfxr: failed to set APP_CONTEXT_BASE_DIRECTORY" << std::endl;
@@ -333,7 +136,7 @@ static int stage1_main(void) {
         exit(rc);
     }
 
-    // STEP 8:
+    // STEP 10:
     // Get function pointers to HostFxr's `load_assembly()` and `get_function_pointer()`.
     rc = g_fnptr_hostfxr_get_delegate(
         cxt,
@@ -362,12 +165,12 @@ static int stage1_main(void) {
     load_assembly_fn        fnptr_hostfxr_load_assembly        = (load_assembly_fn)       ptr_hostfxr_load_assembly;
     get_function_pointer_fn fnptr_hostfxr_get_function_pointer = (get_function_pointer_fn)ptr_hostfxr_get_function_pointer;
 
-    // STEP 9:
+    // STEP 11:
     // Load managed assembly and get function pointer to bootstrap function.
     fh_init fnptr_fh_init = nullptr;
 
     rc = fnptr_hostfxr_load_assembly(
-        clrhost_lib_path.c_str(),
+        path_fh_dll.c_str(),
         nullptr,
         nullptr);
 
@@ -378,8 +181,8 @@ static int stage1_main(void) {
     }
 
     rc = fnptr_hostfxr_get_function_pointer(
-        clrhost_type,
-        clrhost_init_method,
+        fh_init_type,
+        fh_init_method,
         UNMANAGEDCALLERSONLY_METHOD,
         nullptr,
         nullptr,
@@ -391,26 +194,86 @@ static int stage1_main(void) {
         exit(rc);
     }
 
-    // STEP 10:
+    // STEP 12:
     // Boot Fahrenheit by invoking the boot function in `fh.dll`.
 
     // TRANSITION: NATIVE -> MANAGED
     fnptr_fh_init();
     // TRANSITION: MANAGED -> NATIVE
 
-    // STEP 11:
-    // Change the working directory to the targeted executable's location,
-    // now that we have finished initialization.
-    rc = _wchdir(host_path.c_str());
-    if (rc != 0) {
-        std::wcerr << "Failed to switch to the game's working directory." << std::endl;
-        exit(rc);
-    }
-
-    // STEP 11:
+    // STEP 13:
     // Let the game run. Enjoy!
     std::wcout << "Stage 1 Loader complete. The game is now executing." << std::endl;
     return g_fnptr_main_original();
+}
+
+/* [fkelava 21/08/26 14:09]
+ * Records the name of the module we're being loaded into and the directory we started from,
+ * switches the current working directory to the target's, and hooks its entrypoint.
+ * 
+ * This is required because certain other tools expect the game's working directory to be
+ * unmodified when they load into the process, which occurs immediately after Stage 1 exits `DllMain`.
+ */
+static BOOL stage1_init() {
+    auto path_target_size = ::GetModuleFileNameW(
+        NULL, 
+        path_target_buf, 
+        sizeof(path_target_buf) / sizeof(char_t)
+    );
+
+    auto path_cwd_size = ::GetCurrentDirectoryW(
+        sizeof(path_fh_buf) / sizeof(char_t), 
+        path_fh_buf
+    );
+
+    if (path_target_size == 0) {
+        std::wcerr << "GetModuleFileName() failed." << std::endl;
+        return FALSE;
+    }
+
+    if (path_cwd_size == 0) {
+        std::wcerr << "GetCurrentDirectory() failed." << std::endl;
+        return FALSE;
+    }
+
+    HRESULT hr = PathCchRemoveFileSpec(path_target_buf, MAX_PATH);
+    if (hr != S_OK) {
+        std::wcerr << "PathCchRemoveFileSpec() failed, error code: " << hr << std::endl;
+        return FALSE;
+    }
+
+    std::basic_string<char_t> target_path = path_target_buf;
+    std::wcout << "Stage 1 Loader executing for: " << target_path << std::endl;
+
+    // STEP 2:
+    // Change the working directory to the targeted executable's location.
+    int rc = _wchdir(target_path.c_str());
+    if (rc != 0) {
+        std::wcerr << "Failed to switch to the game's working directory." << std::endl;
+        return FALSE;
+    }
+
+    // STEP 3:
+    // Override the program entrypoint. We need to run Fahrenheit initialization first.
+    HMODULE hMainModule = GetModuleHandleW(nullptr);
+    LPBYTE  pMainModule = reinterpret_cast<LPBYTE>(hMainModule);
+
+    PIMAGE_DOS_HEADER pImgDosHeaders = reinterpret_cast<PIMAGE_DOS_HEADER>(hMainModule);
+    if (pImgDosHeaders->e_magic != IMAGE_DOS_SIGNATURE)
+        return FALSE;
+
+    PIMAGE_NT_HEADERS pImgNTHeaders = reinterpret_cast<PIMAGE_NT_HEADERS>((pMainModule + pImgDosHeaders->e_lfanew));
+    if (pImgNTHeaders->Signature != IMAGE_NT_SIGNATURE)
+        return FALSE;
+
+    g_fnptr_main_target = reinterpret_cast<main_fn>(pMainModule + pImgNTHeaders->OptionalHeader.AddressOfEntryPoint);
+
+    if (MH_Initialize() != MH_OK
+    ||  MH_CreateHook(g_fnptr_main_target, &stage1_main, reinterpret_cast<void**>(&g_fnptr_main_original)) != MH_OK
+    ||  MH_EnableHook(g_fnptr_main_target) != MH_OK)
+        return FALSE;
+
+    return TRUE;
 }
 
 BOOL APIENTRY DllMain(
@@ -420,27 +283,12 @@ BOOL APIENTRY DllMain(
 ) {
     switch (reason) {
         case DLL_PROCESS_ATTACH: {
+            // STEP 1:
             // Return the IAT to its original self.
             if (!DetourRestoreAfterWith())
-                exit(GetLastError());
-
-            // Override the program's entrypoint. We need to host the .NET Runtime and boot Fahrenheit first.
-            HMODULE hMainModule = GetModuleHandleW(nullptr);
-            LPBYTE  pMainModule = reinterpret_cast<LPBYTE>(hMainModule);
-
-            PIMAGE_DOS_HEADER pImgDosHeaders = reinterpret_cast<PIMAGE_DOS_HEADER>(hMainModule);
-            if (pImgDosHeaders->e_magic  != IMAGE_DOS_SIGNATURE)
                 return FALSE;
 
-            PIMAGE_NT_HEADERS pImgNTHeaders  = reinterpret_cast<PIMAGE_NT_HEADERS>((pMainModule + pImgDosHeaders->e_lfanew));
-            if (pImgNTHeaders->Signature != IMAGE_NT_SIGNATURE)
-                return FALSE;
-
-            g_fnptr_main_target = reinterpret_cast<main_fn>(pMainModule + pImgNTHeaders->OptionalHeader.AddressOfEntryPoint);
-
-            if (MH_Initialize()                                                                                    != MH_OK
-            ||  MH_CreateHook(g_fnptr_main_target, &stage1_main, reinterpret_cast<void**>(&g_fnptr_main_original)) != MH_OK
-            ||  MH_EnableHook(g_fnptr_main_target)                                                                 != MH_OK)
+            if (!stage1_init())
                 return FALSE;
         }
         case DLL_THREAD_ATTACH:


### PR DESCRIPTION
There is a strange, unspoken detail about Fahrenheit initialization: `init` runs with the working directory still set to `fahrenheit/bin`, and is then changed immediately thereafter. This means that relative paths can resolve to two different places before and after `init`, which can range from being merely unexpected to having serious consequences.

The other consequence thereof is that anything relying on the game's working directory being 'normally' set, most notably [ffgriever's EFL](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader), can't work. But it doesn't have to be like this.

We _can_, in fact, fix this; `fhstage1` is guaranteed to load first, and we can instantly change the working directory instead of doing it after initializing Fahrenheit. The rest of Stage1 and Fahrenheit must be amended accordingly.

I also took the liberty of splitting out S1 EH into a separate code file for ease of maintenance.