### PR TITLE
Short-circuit subsequent texture (un)loads

### DIFF
--- a/src/core/resload.cs
+++ b/src/core/resload.cs
@@ -189,7 +189,7 @@ public sealed class FhResources {
     /// </remarks>
     /// <returns>Whether the operation succeeded and <paramref name="texture"/> can be passed to ImGui for rendering.</returns>
     public bool load_texture_from_disk(FhTexture texture) {
-        return loader.get_impl(out IFhResourceLoader? impl) && impl.load_texture_from_disk(texture);
+        return texture.is_loaded() || (loader.get_impl(out IFhResourceLoader? impl) && impl.load_texture_from_disk(texture));
     }
 
     /// <summary>
@@ -197,7 +197,7 @@ public sealed class FhResources {
     /// </summary>
     /// <returns>Whether the operation succeeded and <paramref name="texture"/> can be passed to ImGui for rendering.</returns>
     public bool load_game_texture_2d(FhTexture texture) {
-        return loader.get_impl(out IFhResourceLoader? impl) && impl.load_game_texture_2d(texture);
+        return texture.is_loaded() || (loader.get_impl(out IFhResourceLoader? impl) && impl.load_game_texture_2d(texture));
     }
 
     /// <summary>
@@ -205,7 +205,7 @@ public sealed class FhResources {
     /// </summary>
     /// <returns>Whether the operation succeeded and <paramref name="texture"/> can be passed to ImGui for rendering.</returns>
     public bool load_game_texture_3d(FhTexture texture) {
-        return loader.get_impl(out IFhResourceLoader? impl) && impl.load_game_texture_3d(texture);
+        return texture.is_loaded() || (loader.get_impl(out IFhResourceLoader? impl) && impl.load_game_texture_3d(texture));
     }
 
     /// <summary>
@@ -213,7 +213,7 @@ public sealed class FhResources {
     /// </summary>
     /// <returns>Whether the operation succeeded and <paramref name="texture"/> can be passed to ImGui for rendering.</returns>
     public bool load_game_texture_cubemap(FhTexture texture) {
-        return loader.get_impl(out IFhResourceLoader? impl) && impl.load_game_texture_cubemap(texture);
+        return texture.is_loaded() || (loader.get_impl(out IFhResourceLoader? impl) && impl.load_game_texture_cubemap(texture));
     }
 
     /// <summary>
@@ -223,6 +223,6 @@ public sealed class FhResources {
     ///     <c>false</c> if the texture is locked or pending unload, otherwise <c>true</c>.
     /// </returns>
     public bool unload_texture(FhTexture texture) {
-        return loader.get_impl(out IFhResourceLoader? impl) && impl.unload_texture(texture);
+        return !texture.is_loaded() || (loader.get_impl(out IFhResourceLoader? impl) && impl.unload_texture(texture));
     }
 }

--- a/src/runtime/resloader.cs
+++ b/src/runtime/resloader.cs
@@ -80,7 +80,7 @@ public unsafe sealed class FhResourceLoaderModule : FhModule, IFhResourceLoader,
             return false;
         }
 
-        if (texture.is_loaded() || !texture.try_lock())
+        if (!texture.try_lock())
             return false;
 
         Hexa_TexMetadata  image_metadata = default;
@@ -119,7 +119,7 @@ public unsafe sealed class FhResourceLoaderModule : FhModule, IFhResourceLoader,
             return false;
         }
 
-        if (texture.is_loaded() || !texture.try_lock())
+        if (!texture.try_lock())
             return false;
 
         using FhPClusterScope cluster_scope = _plm!.cluster_load(tex_path);
@@ -195,7 +195,7 @@ public unsafe sealed class FhResourceLoaderModule : FhModule, IFhResourceLoader,
             return false;
         }
 
-        if (texture.is_loaded() || !texture.try_lock())
+        if (!texture.try_lock())
             return false;
 
         using FhPClusterScope cluster_scope = _plm!.cluster_load(tex_path);
@@ -239,7 +239,7 @@ public unsafe sealed class FhResourceLoaderModule : FhModule, IFhResourceLoader,
             return false;
         }
 
-        if (texture.is_loaded() || !texture.try_lock())
+        if (!texture.try_lock())
             return false;
 
         using FhPClusterScope cluster_scope = _plm!.cluster_load(tex_path);
@@ -293,9 +293,6 @@ public unsafe sealed class FhResourceLoaderModule : FhModule, IFhResourceLoader,
 
     bool IFhResourceLoader.unload_texture(FhTexture texture) {
         lock (_release_lock) {
-            if (!texture.is_loaded())
-                return true;
-
             return texture.try_lock() && _release_queue.Add(texture);
         }
     }


### PR DESCRIPTION
Due to some gratuitous stupidity on my behalf, `load_*_texture` would return `true` on a successful load but then `false` on a subsequent call, even though the texture was already loaded. This makes it confusing to impossible to write a simple load-all routine, so let's do that correctly now.