### PR TITLE
Simplify the README substantially

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,26 @@
+Ensure the folder you cloned to does not contain special characters. This can cause build errors.
+
+Building **requires** Visual Studio 2026 (full IDE or Build Tools only) with the following workloads:
+- .NET desktop development (latest version)
+- C++ desktop development (latest version)
+
+Once you have installed Visual Studio, enable the `vcpkg` package manager
+by issuing `vcpkg integrate install` at a Developer PowerShell prompt.
+Restart Visual Studio if it was open during this process.
+
+To build at a Developer PowerShell:
+```
+msbuild .\Fahrenheit.slnx /t:Restore /p:Configuration=Release
+msbuild .\Fahrenheit.slnx /p:Configuration=Release
+```
+If using Visual Studio, `Build Solution` performs everything for you.
+For a Debug build, change the `Configuration` parameter to `Debug`.
+
+To install/test your development build:
+- Create a subfolder in your game directory (where ``FFX.exe`` is) named ``fahrenheit``.
+- In the directory in which you cloned Fahrenheit, navigate to ``artifacts\deploy``, then ``dbg`` or ``rel`` depending on build type (Debug or Release).
+- Copy its contents (the folders ``bin``, ``mods``, etc.) to the ``fahrenheit`` subfolder in the game directory.
+- Create an empty, extensionless file called `loadorder` in the `mods` directory. Add the manifest names of mods you wish to load, each on their own line.
+- Open a terminal in ``fahrenheit/bin``, then issue ``.\fhstage0.exe ..\..\FFX.exe``.
+- Debugging can be performed from Visual Studio. Attach to either ``fhstage0.exe`` or ``FFX.exe``,
+and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,11 +1,34 @@
 Ensure the folder you cloned to does not contain special characters. This can cause build errors.
 
-Building **requires** Visual Studio 2026 (full IDE or Build Tools only) with the following workloads:
-- .NET desktop development (latest version)
-- C++ desktop development (latest version)
+Fahrenheit is generally subdivided into two parts:
+- The native (C++) components. These are the Stage 0 (`src/stage0`) and Stage 1 (`src/stage1`) loaders.
+- The managed (.NET) components. These are the core library, SDK, runtime and tools, and any mods.
+
+All systems can build the managed components. Windows systems can perform full builds.
+
+## Managed component build
+
+One of the following is required:
+- A .NET IDE such as [JetBrains Rider](https://www.jetbrains.com/rider/) or [Visual Studio](https://visualstudio.microsoft.com/).
+- The CLI [.NET SDK](https://dotnet.microsoft.com/en-us/download).
+
+To build them all:
+- With a .NET IDE, build the solution.
+- With the .NET SDK, run `dotnet build -c {Debug|Release} .\Fahrenheit.slnx` in the folder you cloned Fahrenheit to.
+
+Errors relating to the 'Stage 0' and 'Stage 1' loader projects may be ignored.
+
+You can use a copy of the Stage 0 and Stage 1 loaders from the latest [release](https://github.com/fahrenheit-crew/fahrenheit/releases) on systems that cannot build them to compose a complete build.
+
+## Native component or full build
+
+Requires Visual Studio 2026 on Windows (IDE or Build Tools only) with the following workloads:
+- C++ desktop development
+- .NET desktop development (if performing a full build)
 
 Once you have installed Visual Studio, enable the `vcpkg` package manager
 by issuing `vcpkg integrate install` at a Developer PowerShell prompt.
+
 Restart Visual Studio if it was open during this process.
 
 To build at a Developer PowerShell:
@@ -13,8 +36,11 @@ To build at a Developer PowerShell:
 msbuild .\Fahrenheit.slnx /t:Restore /p:Configuration=Release
 msbuild .\Fahrenheit.slnx /p:Configuration=Release
 ```
-If using Visual Studio, `Build Solution` performs everything for you.
+Alternatively, `Build Solution` in the IDE performs everything for you.
+
 For a Debug build, change the `Configuration` parameter to `Debug`.
+
+## Deploying/installing and debugging a local build
 
 To install/test your development build:
 - Create a subfolder in your game directory (where ``FFX.exe`` is) named ``fahrenheit``.

--- a/BUILD.md
+++ b/BUILD.md
@@ -46,7 +46,7 @@ To install/test your development build:
 - Create a subfolder in your game directory (where ``FFX.exe`` is) named ``fahrenheit``.
 - In the directory in which you cloned Fahrenheit, navigate to ``artifacts\deploy``, then ``dbg`` or ``rel`` depending on build type (Debug or Release).
 - Copy its contents (the folders ``bin``, ``mods``, etc.) to the ``fahrenheit`` subfolder in the game directory.
-- Create an empty, extensionless file called `loadorder` in the `mods` directory. Add the manifest names of mods you wish to load, each on their own line.
+- Create an empty, extensionless file called `loadorder` in the `mods` directory. Add the mod IDs of mods you wish to load, each on their own line.
 - Open a terminal in ``fahrenheit/bin``, then issue ``.\fhstage0.exe ..\..\FFX.exe``.
 - Debugging can be performed from Visual Studio. Attach to either ``fhstage0.exe`` or ``FFX.exe``,
 and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).

--- a/Fahrenheit.slnx
+++ b/Fahrenheit.slnx
@@ -7,6 +7,7 @@
   </Configurations>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path="BUILD.md" />
     <File Path="COPYING" />
     <File Path="COPYING.LESSER" />
     <File Path="Directory.Build.props" />

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Grab the latest binaries from the [releases page](https://github.com/fahrenheit-
 then follow the [installation guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Installation-guide).
 
 ## For developers
-Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build-and-deployment-guide) to get started.
+Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build-and-deployment-guide) (or `BUILD.md` locally) to get started.
 
 ## For modders
 See the [template](https://github.com/fahrenheit-crew/fh-mods-template) and [TrueRNG mod](https://github.com/fahrenheit-crew/fh-mods-truerng) to get started.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,8 @@ It is also the leading repository of knowledge about the games, underpinning oth
 This know-how is free for you to use, learn from, analyze, and improve.
 
 ## Here just to play?
-Grab the latest binaries from the [releases page](https://github.com/fahrenheit-crew/fahrenheit/releases).
-
-Install by unpacking the contents of a release ZIP into a folder called `fahrenheit` in your game directory (where `FFX.exe` is).
-
-Before using Fahrenheit, ensure you've carefully read its [compatibility notes](https://github.com/fahrenheit-crew/fahrenheit/wiki/Compatibility-notes).
+Grab the latest binaries from the [releases page](https://github.com/fahrenheit-crew/fahrenheit/releases), 
+then follow the [installation guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Installation-guide).
 
 ## For developers
 Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build,-deployment,-and-debugging) to get started.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Grab the latest binaries from the [releases page](https://github.com/fahrenheit-
 then follow the [installation guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Installation-guide).
 
 ## For developers
-Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build,-deployment,-and-debugging) to get started.
+Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build-and-deployment-guide) to get started.
 
 ## For modders
 See the [template](https://github.com/fahrenheit-crew/fh-mods-template) to get started.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,36 @@
 # Fahrenheit
 
-A Final Fantasy X/X-2 reverse-engineering project and mod framework.
-
 ![banner](https://raw.githubusercontent.com/fahrenheit-crew/fahrenheit/refs/heads/main/assets/fh_banner.png)
 
-## What is Fahrenheit?
 Fahrenheit is a reverse-engineering project and mod framework for the [Final Fantasy X and X-2 HD Remasters](https://store.steampowered.com/app/359870/).
 
-It allows you to freely hook game functions and distribute mods in the form of loadable DLLs.
-Fahrenheit hosts the [.NET runtime](https://dotnet.microsoft.com/en-us/download)
-within the games, allowing you to write mods in any compatible language.
+It provides a comprehensive, ever-growing set of tools for interfacing with the games and their data,
+allowing you to modify the game at an unparalleled level and develop entirely new features for it.
 
-The knowledge gathered by the project underpins many tools and mods for the game, such as the
-[AI/VI TAS](https://github.com/coderwilson/FFX_TAS_Python), [Cutscene Remover](https://github.com/erickt420/FFXCutsceneRemover) mod,
-[Karifean](https://github.com/Karifean)'s [FFXDataParser](https://github.com/Karifean/FFXDataParser), and more.
-Fahrenheit, like all of these tools, is free for you to analyze, improve, learn from and use- now and forever.
+It is also the leading repository of knowledge about the games, underpinning other state-of-the-art tools.
+This know-how is free for you to use, learn from, analyze, and improve.
 
-## Build and deploy
-Ensure the folder you cloned to does not contain special characters. This can cause build errors.
+## Here just to play?
+Grab the latest binaries from the [releases page](https://github.com/fahrenheit-crew/fahrenheit/releases).
 
-Building **requires** Visual Studio 2026 (full IDE or Build Tools only) with the following workloads:
-- .NET desktop development (latest version)
-- C++ desktop development (latest version)
+Install by unpacking the contents of a release ZIP into a folder called `fahrenheit` in your game directory (where `FFX.exe` is).
 
-Once you have installed Visual Studio, enable the `vcpkg` package manager
-by issuing `vcpkg integrate install` at a Developer PowerShell prompt.
-Restart Visual Studio if it was open during this process.
+Before using Fahrenheit, ensure you've carefully read its [compatibility notes](https://github.com/fahrenheit-crew/fahrenheit/wiki/Compatibility-notes).
 
-To build at a Developer PowerShell:
-```
-msbuild .\Fahrenheit.slnx /t:Restore /p:Configuration=Release
-msbuild .\Fahrenheit.slnx /p:Configuration=Release
-```
-If using Visual Studio, `Build Solution` performs everything for you.
-For a Debug build, change the `Configuration` parameter to `Debug`.
+## For developers
+Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build,-deployment,-and-debugging) to get started.
 
-To install/test your development build:
-- Create a subfolder in your game directory (where ``FFX.exe`` is) named ``fahrenheit``.
-- In the directory in which you cloned Fahrenheit, navigate to the ``artifacts\deploy`` subdirectory.
-- Depending on build type (Debug or Release), navigate to the ``dbg`` or ``rel`` subdirectory.
-- Copy the contents of that directory (the folders ``bin``, ``mods``, etc.) to the ``fahrenheit`` subfolder in the game directory.
-- Create an empty, extensionless file called `loadorder` in the `mods` directory. Add the manifest names of mods you wish to load, each on their own line.
-- Open a terminal in ``fahrenheit/bin``, then issue ``.\fhstage0.exe ..\..\FFX.exe``.
-- Debugging can be performed from Visual Studio. Attach to either ``fhstage0.exe`` or ``FFX.exe``,
-and make sure to enable [mixed-mode debugging](https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-debug-managed-and-native-code?view=vs-2022).
+## For modders
+See the [template](https://github.com/fahrenheit-crew/fh-mods-template) to get started.
 
-## Compatibility notes
-Do not run either the game or Fahrenheit as an administrator. This does not work and is strictly unsupported. 
-If you see a UAC icon (little shield) over your game executable, right click it, go to `Properties > Compatibility`, 
-and ensure `Run this program as an administrator` is **not checked**.
+## Got issues, or want to contribute?
+Feel free to join us in [Cid's Salvage Ship](https://discord.gg/AGx2grw9nD), a Discord server that supports Fahrenheit and related efforts.
 
-Fahrenheit comes with an integrated external file loader. If you simultaneously use ffgriever's
-[External File Loader for FFX/FFX-2](https://gitlab.com/ffgriever/ffx-x-2-hd-external-file-loader), the resulting behavior is undefined.
-
-If you use [Untitled Project X](https://github.com/Kaldaien/UnX) with Fahrenheit,
-you **must** patch the game executable to be large-address-aware (apply the "4GB patch"). If you don't, you will run out of memory at boot.
-
-If you use [RivaTuner Statistics Server](https://www.guru3d.com/download/rtss-rivatuner-statistics-server-download/) with Fahrenheit,
-you **must** enable 'Use Microsoft Detours API hooking' in `Setup > General > Compatibility properties`.
-
-## What's next?
-Time permitting, the goals (in no specific order) of the project are:
-- Provide actual code-behind, helper functions, and tooling to make various modding tasks approachable.
-- Provide a mod manager for end users who simply want to enjoy the game.
-- Provide quality documentation for various implementation-specific details and game systems.
-- In general, _polish_ every aspect of the solution.
-
-## Can I contribute?
-Yes. Feel free to join us in [Cid's Salvage Ship](https://discord.gg/AGx2grw9nD), a Discord server that supports Fahrenheit and related efforts.
+## Looking for more?
+Also check out:
+- [Karifean](https://github.com/Karifean)'s [FFXDataParser](https://github.com/Karifean/FFXDataParser).
+- The [Cutscene Remover](https://github.com/erickt420/FFXCutsceneRemover) mod.
+- The [Archipelago](https://github.com/FFX-AP/Archipelago-FFX-Client/wiki) mod.
 
 ## License
 Fahrenheit source code is licensed under the [LGPL 3.0 or later](https://github.com/fahrenheit-crew/fahrenheit/blob/main/COPYING.LESSER) license.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ then follow the [installation guide](https://github.com/fahrenheit-crew/fahrenhe
 Read the [build, deployment and debugging guide](https://github.com/fahrenheit-crew/fahrenheit/wiki/Build-and-deployment-guide) to get started.
 
 ## For modders
-See the [template](https://github.com/fahrenheit-crew/fh-mods-template) to get started.
+See the [template](https://github.com/fahrenheit-crew/fh-mods-template) and [TrueRNG mod](https://github.com/fahrenheit-crew/fh-mods-truerng) to get started.
 
-## Got issues, or want to contribute?
+## Need help, or want to contribute?
 Feel free to join us in [Cid's Salvage Ship](https://discord.gg/AGx2grw9nD), a Discord server that supports Fahrenheit and related efforts.
 
 ## Looking for more?


### PR DESCRIPTION
Move out a few things from the `README` into wiki links, and simplify some other explanations.

The goal is to explain what Fahrenheit is and how to get started faster than previously.