### PR TITLE
Improve the player experience in the save UI when fading in

### DIFF
--- a/src/core/gui/fade.cs
+++ b/src/core/gui/fade.cs
@@ -7,8 +7,8 @@ namespace Fahrenheit.Gui;
 
 /// <summary>Provides utilities to help with fading from one color to another.</summary>
 public class FadeHelper : Timer {
-    protected uint color_from;
-    protected uint color_to;
+    public uint color_from { get; protected set; }
+    public uint color_to   { get; protected set; }
 
     /// <summary>
     ///     Create a new FadeHelper to fade from and to specified colors over a given amount of time.

--- a/src/core/gui/fade.cs
+++ b/src/core/gui/fade.cs
@@ -7,8 +7,8 @@ namespace Fahrenheit.Gui;
 
 /// <summary>Provides utilities to help with fading from one color to another.</summary>
 public class FadeHelper : Timer {
-    public uint color_from { get; protected set; }
-    public uint color_to   { get; protected set; }
+    protected uint color_from;
+    protected uint color_to;
 
     /// <summary>
     ///     Create a new FadeHelper to fade from and to specified colors over a given amount of time.

--- a/src/core/gui/fade.cs
+++ b/src/core/gui/fade.cs
@@ -53,6 +53,10 @@ public class FadeHelper : Timer {
         remaining = length;
 
         on_end = when_done;
+
+        if (length < 0.0001f && on_end is not null) {
+            on_end();
+        }
     }
 
     /// <summary>Calculate the current color.</summary>

--- a/src/core/gui/timer.cs
+++ b/src/core/gui/timer.cs
@@ -38,16 +38,21 @@ public class Timer {
     public Timer(float time, Action? when_done = null) {
         remaining = length = time;
         on_end    = when_done;
+
+        if (length < 0.0001f && on_end is not null) {
+            on_end();
+        }
     }
 
     /// <summary>Reduce the remaining time in the timer down by the specified delta time.</summary>
     /// <param name="delta">The amount of time to reduce the remaining time by.</param>
     /// <returns>Whether the timer has finished running with this tick.</returns>
     public bool tick(float delta) {
+        float old_remaining = remaining;
         remaining = float.Max(remaining - delta, 0f);
 
-        if (is_done && on_end is {} when_done) {
-            when_done();
+        if (old_remaining > remaining && is_done && on_end is not null) {
+            on_end();
         }
 
         return is_done;
@@ -64,5 +69,9 @@ public class Timer {
         remaining = length;
 
         on_end = when_done;
+
+        if (length < 0.0001f && on_end is not null) {
+            on_end();
+        }
     }
 }

--- a/src/core/gui/timer.cs
+++ b/src/core/gui/timer.cs
@@ -41,6 +41,7 @@ public class Timer {
 
         if (length < 0.0001f && on_end is not null) {
             on_end();
+            on_end = null; // Prevent the on_end action from executing twice
         }
     }
 
@@ -53,6 +54,7 @@ public class Timer {
 
         if (old_remaining > remaining && is_done && on_end is not null) {
             on_end();
+            on_end = null; // Prevent the on_end action from executing twice
         }
 
         return is_done;
@@ -72,6 +74,7 @@ public class Timer {
 
         if (length < 0.0001f && on_end is not null) {
             on_end();
+            on_end = null; // Prevent the on_end action from executing twice
         }
     }
 }

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -94,8 +94,8 @@ public sealed class FhSaveUiX : FhSaveUi {
 
     // We block input when fading out, for example so you can't requests two loads of a file.
     // We block input when fading in as well, but only for a short time to make the UI feel snappy.
-    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f);
-    private bool should_handle_input => !_scrollbar_dragging && is_fade_blocking_input;
+    private bool is_fade_blocking_input => !(_fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f));
+    private bool should_handle_input => !_scrollbar_dragging && !is_fade_blocking_input;
 
     public FhSaveUiX() {
         _current_scrollable     = _scrollable_saves;

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -153,18 +153,18 @@ public sealed class FhSaveUiX : FhSaveUi {
         );
     }
 
-    private void handle_input_list() {
+    private bool handle_input_list() {
         if (_mode == UiMode.SAVE_LIST) {
             if (_scrollable_saves.max == 0) {
                 _focus = UiFocus.ACTIVE_SET;
-                return;
+                return false;
             }
 
             if (FhApi.Gui.is_any_pressed(FhApi.Gui.keys_up)
              && _current_scrollable.hovered == 0
             ) {
                 _focus = UiFocus.ACTIVE_SET;
-                return;
+                return true;
             }
         }
 
@@ -182,37 +182,49 @@ public sealed class FhSaveUiX : FhSaveUi {
                     fade_out(() => execute(save.slot));
                 }
 
-                return;
+                return true;
             }
 
             if (_mode == UiMode.SET_SWAP) {
                 string hovered_set = _set_list[hovered];
                 switch_set(hovered_set);
 
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 
-    private void handle_input_active_set() {
+    private bool handle_input_active_set() {
         if (_mode == UiMode.SAVE_LIST && FhApi.Gui.is_any_pressed(FhApi.Gui.keys_down) && _current_scrollable.max > 0) {
             _focus = UiFocus.LIST;
             _current_scrollable.hovered = _current_scrollable.current;
 
-            return;
+            return true;
         }
 
         if (FhApi.Gui.is_any_pressed(FhApi.Gui.keys_confirm)) {
             change_mode(UiMode.SET_SWAP);
+            return true;
         }
+
+        return false;
     }
 
     private void handle_input() {
         if (!should_handle_input) return;
 
         switch (_focus) {
-            case UiFocus.LIST:       handle_input_list();       break;
-            case UiFocus.ACTIVE_SET: handle_input_active_set(); break;
+            case UiFocus.LIST:
+                if (handle_input_list())
+                    return;
+                break;
+
+            case UiFocus.ACTIVE_SET:
+                if (handle_input_active_set())
+                    return;
+                break;
 
             default: throw new NotImplementedException();
         }

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -175,7 +175,7 @@ public sealed class FhSaveUiX : FhSaveUi {
 
             if (_mode == UiMode.SAVE_LIST) {
                 if (is_saving && hovered == 0) {
-                    FhApi.Saves.save(0);
+                    fade_out(() => FhApi.Saves.save(0));
                 }
                 else {
                     FhSaveDisplayData save = FhApi.Saves.display_data[hovered];

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -48,7 +48,7 @@ public sealed class FhSaveUiX : FhSaveUi {
     private UiMode  _mode;
     private UiFocus _focus;
 
-    private          float      _fade_length = FhUtil.select(0.5f, 0.35f, 0.01f);
+    private readonly float      _fade_length = FhUtil.select(0.5f, 0.35f, 0.0f);
     private readonly FadeHelper _fade;
 
     private readonly List<string> _set_list = [ ];

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -766,7 +766,7 @@ public sealed class FhSaveUiX : FhSaveUi {
             ? display_data.Count + 1
             : display_data.Count;
 
-         if (!is_saving && display_data.Count == 0) {
+        if (!is_saving && display_data.Count == 0) {
             ui_no_saves();
             return;
         }

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -1156,7 +1156,7 @@ public sealed class FhSaveUiX : FhSaveUi {
 
         // Handle input
         if (mouse_clicked(save_rect.scale_to_aspect(aspect_helper))) {
-            FhApi.Saves.save(0);
+            fade_out(() => FhApi.Saves.save(0));
         }
     }
 

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -95,7 +95,7 @@ public sealed class FhSaveUiX : FhSaveUi {
     // We block input when fading out, for example so you can't requests two loads of a file.
     // We block input when fading in as well, but only for a short time to make the UI feel snappy.
     private bool is_fade_blocking_input => !(_fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f));
-    private bool should_handle_input => !_scrollbar_dragging && !is_fade_blocking_input;
+    private bool should_handle_input    => !_scrollbar_dragging && !is_fade_blocking_input;
 
     public FhSaveUiX() {
         _current_scrollable     = _scrollable_saves;

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -215,19 +215,8 @@ public sealed class FhSaveUiX : FhSaveUi {
     private void handle_input() {
         if (!should_handle_input) return;
 
-        switch (_focus) {
-            case UiFocus.LIST:
-                if (handle_input_list())
-                    return;
-                break;
-
-            case UiFocus.ACTIVE_SET:
-                if (handle_input_active_set())
-                    return;
-                break;
-
-            default: throw new NotImplementedException();
-        }
+        if (_focus == UiFocus.LIST       && handle_input_list())       return;
+        if (_focus == UiFocus.ACTIVE_SET && handle_input_active_set()) return;
 
         if (FhApi.Gui.is_any_pressed(FhApi.Gui.keys_cancel)) {
             if (_mode == UiMode.SET_SWAP)

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -48,7 +48,8 @@ public sealed class FhSaveUiX : FhSaveUi {
     private UiMode  _mode;
     private UiFocus _focus;
 
-    private readonly FadeHelper _fade = new(0, 0, 0.5f);
+    private          float      _fade_length = FhUtil.select(0.5f, 0.35f, 0.01f);
+    private readonly FadeHelper _fade;
 
     private readonly List<string> _set_list = [ ];
 
@@ -91,7 +92,10 @@ public sealed class FhSaveUiX : FhSaveUi {
     private bool     _scrollbar_dragging;
     private Vector2? _scrollbar_held_pos;
 
-    private bool should_handle_input => !_scrollbar_dragging && _fade.is_done;
+    // We block input when fading out, for example so you can't requests two loads of a file.
+    // We block input when fading in as well, but only for a short time to make the UI feel snappy.
+    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.1f);
+    private bool should_handle_input => !_scrollbar_dragging && is_fade_blocking_input;
 
     public FhSaveUiX() {
         _current_scrollable     = _scrollable_saves;
@@ -101,6 +105,8 @@ public sealed class FhSaveUiX : FhSaveUi {
             new(450f, 609f),
             new(  9f,   9f)
         );
+
+        _fade = new(0, 0, _fade_length);
     }
 
     public override bool init(FhModContext context, FileStream global_state) {
@@ -138,6 +144,15 @@ public sealed class FhSaveUiX : FhSaveUi {
         ui_fade();
     }
 
+    private void fade_out(Action action) {
+        _fade.restart(
+            _fade.get_color(),
+            COLOR_BLACK,
+            _fade_length * _fade.progress,
+            action
+        );
+    }
+
     private void handle_input_list() {
         if (_mode == UiMode.SAVE_LIST) {
             if (_scrollable_saves.max == 0) {
@@ -164,12 +179,7 @@ public sealed class FhSaveUiX : FhSaveUi {
                 }
                 else {
                     FhSaveDisplayData save = FhApi.Saves.display_data[hovered];
-                    _fade.restart(
-                        COLOR_TRANS,
-                        COLOR_BLACK,
-                        null,
-                        () => execute(save.slot)
-                    );
+                    fade_out(() => execute(save.slot));
                 }
 
                 return;
@@ -211,12 +221,7 @@ public sealed class FhSaveUiX : FhSaveUi {
             if (_mode == UiMode.SET_SWAP)
                 change_mode(UiMode.SAVE_LIST);
             else
-                _fade.restart(
-                    COLOR_TRANS,
-                    COLOR_BLACK,
-                    null,
-                    () => FhApi.Saves.exit_cancel()
-                );
+                fade_out(() => FhApi.Saves.exit_cancel());
         }
     }
 
@@ -235,7 +240,7 @@ public sealed class FhSaveUiX : FhSaveUi {
             ? FhApi.Saves.get_slots_used() + 1 // Add one for New Save Data button
             : FhApi.Saves.display_data.Count;
 
-        _fade.restart(COLOR_BLACK, COLOR_TRANS);
+        _fade.restart(COLOR_BLACK, COLOR_TRANS, _fade_length);
     }
 
     private void post_close(EventArgs e) {
@@ -1072,12 +1077,7 @@ public sealed class FhSaveUiX : FhSaveUi {
 
         // Handle input
         if (mouse_clicked(save_rect.scale_to_aspect(aspect_helper))) {
-            _fade.restart(
-                COLOR_TRANS,
-                COLOR_BLACK,
-                null,
-                () => execute(save.slot)
-            );
+            fade_out(() => execute(save.slot));
         }
     }
 

--- a/src/runtime/gui/save_ffx.cs
+++ b/src/runtime/gui/save_ffx.cs
@@ -94,7 +94,7 @@ public sealed class FhSaveUiX : FhSaveUi {
 
     // We block input when fading out, for example so you can't requests two loads of a file.
     // We block input when fading in as well, but only for a short time to make the UI feel snappy.
-    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.1f);
+    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f);
     private bool should_handle_input => !_scrollbar_dragging && is_fade_blocking_input;
 
     public FhSaveUiX() {

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -97,7 +97,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
     // We block input when fading out, for example so you can't requests two loads of a file.
     // We block input when fading in as well, but only for a short time to make the UI feel snappy.
     private bool is_fade_blocking_input => !(_fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f));
-    private bool should_handle_input => !_scrollbar_dragging && !is_fade_blocking_input;
+    private bool should_handle_input    => !_scrollbar_dragging && !is_fade_blocking_input;
 
     public FhSaveUiX2() {
         _current_scrollable = _scrollable_saves;

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -96,7 +96,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
 
     // We block input when fading out, for example so you can't requests two loads of a file.
     // We block input when fading in as well, but only for a short time to make the UI feel snappy.
-    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.1f);
+    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f);
     private bool should_handle_input => !_scrollbar_dragging && is_fade_blocking_input;
 
     public FhSaveUiX2() {

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -144,7 +144,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
         _fade.restart(
             _fade.get_color(),
             COLOR_BLACK,
-            _fade_length * (1f - _fade.progress),
+            _fade_length * _fade.progress,
             action
         );
     }

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -211,19 +211,8 @@ public sealed class FhSaveUiX2 : FhSaveUi {
     private void handle_input() {
         if (!should_handle_input) return;
 
-        switch (_focus) {
-            case UiFocus.LIST:
-                if (handle_input_list())
-                    return;
-                break;
-
-            case UiFocus.ACTIVE_SET:
-                if (handle_input_active_set())
-                    return;
-                break;
-
-            default: throw new NotImplementedException();
-        }
+        if (_focus == UiFocus.LIST       && handle_input_list())       return;
+        if (_focus == UiFocus.ACTIVE_SET && handle_input_active_set()) return;
 
         if (FhApi.Gui.is_any_pressed(FhApi.Gui.keys_cancel)) {
             if (_mode == UiMode.SET_SWAP)

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -51,7 +51,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
     private UiMode  _mode;
     private UiFocus _focus;
 
-    private          float      _fade_length = FhUtil.select(0.5f, 0.35f, 0.01f);
+    private readonly float      _fade_length = FhUtil.select(0.5f, 0.35f, 0.0f);
     private readonly FadeHelper _fade;
 
     private readonly List<string> _set_list = [ ];

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -149,18 +149,18 @@ public sealed class FhSaveUiX2 : FhSaveUi {
         );
     }
 
-    private void handle_input_list() {
+    private bool handle_input_list() {
         if (_mode == UiMode.SAVE_LIST) {
             if (_scrollable_saves.max == 0) {
                 _focus = UiFocus.ACTIVE_SET;
-                return;
+                return false;
             }
 
             if (FhApi.Gui.is_any_pressed(FhApi.Gui.keys_up)
              && _current_scrollable.hovered == 0
             ) {
                 _focus = UiFocus.ACTIVE_SET;
-                return;
+                return true;
             }
         }
 
@@ -178,37 +178,49 @@ public sealed class FhSaveUiX2 : FhSaveUi {
                     fade_out(() => execute(save.slot));
                 }
 
-                return;
+                return true;
             }
 
             if (_mode == UiMode.SET_SWAP) {
                 string hovered_set = _set_list[hovered];
                 switch_set(hovered_set);
 
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 
-    private void handle_input_active_set() {
+    private bool handle_input_active_set() {
         if (_mode == UiMode.SAVE_LIST && FhApi.Gui.is_any_pressed(FhApi.Gui.keys_down) && _current_scrollable.max > 0) {
             _focus = UiFocus.LIST;
             _current_scrollable.hovered = _current_scrollable.current;
 
-            return;
+            return true;
         }
 
         if (FhApi.Gui.is_any_pressed(FhApi.Gui.keys_confirm)) {
             change_mode(UiMode.SET_SWAP);
+            return true;
         }
+
+        return false;
     }
 
     private void handle_input() {
         if (!should_handle_input) return;
 
         switch (_focus) {
-            case UiFocus.LIST:       handle_input_list();       break;
-            case UiFocus.ACTIVE_SET: handle_input_active_set(); break;
+            case UiFocus.LIST:
+                if (handle_input_list())
+                    return;
+                break;
+
+            case UiFocus.ACTIVE_SET:
+                if (handle_input_active_set())
+                    return;
+                break;
 
             default: throw new NotImplementedException();
         }

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -96,8 +96,8 @@ public sealed class FhSaveUiX2 : FhSaveUi {
 
     // We block input when fading out, for example so you can't requests two loads of a file.
     // We block input when fading in as well, but only for a short time to make the UI feel snappy.
-    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f);
-    private bool should_handle_input => !_scrollbar_dragging && is_fade_blocking_input;
+    private bool is_fade_blocking_input => !(_fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.3f));
+    private bool should_handle_input => !_scrollbar_dragging && !is_fade_blocking_input;
 
     public FhSaveUiX2() {
         _current_scrollable = _scrollable_saves;

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -51,6 +51,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
     private UiMode  _mode;
     private UiFocus _focus;
 
+    private          float      _fade_length = FhUtil.select(0.5f, 0.35f, 0.01f);
     private readonly FadeHelper _fade;
 
     private readonly List<string> _set_list = [ ];
@@ -93,13 +94,15 @@ public sealed class FhSaveUiX2 : FhSaveUi {
     private bool     _scrollbar_dragging;
     private Vector2? _scrollbar_held_pos;
 
-    private bool should_handle_input => !_scrollbar_dragging && _fade.is_done;
+    // We block input when fading out, for example so you can't requests two loads of a file.
+    // We block input when fading in as well, but only for a short time to make the UI feel snappy.
+    private bool is_fade_blocking_input => _fade.is_done || (_fade.color_to == COLOR_TRANS && _fade.progress > 0.1f);
+    private bool should_handle_input => !_scrollbar_dragging && is_fade_blocking_input;
 
     public FhSaveUiX2() {
         _current_scrollable = _scrollable_saves;
 
-        float fade_duration = FhGlobal.game_id is FhGameId.FFX2 ? 0.35f : 0.01f;
-        _fade = new FadeHelper(0, 0, fade_duration);
+        _fade = new FadeHelper(0, 0, _fade_length);
     }
 
     public override bool init(FhModContext context, FileStream global_state) {
@@ -137,6 +140,15 @@ public sealed class FhSaveUiX2 : FhSaveUi {
         ui_fade();
     }
 
+    private void fade_out(Action action) {
+        _fade.restart(
+            _fade.get_color(),
+            COLOR_BLACK,
+            _fade_length * (1f - _fade.progress),
+            action
+        );
+    }
+
     private void handle_input_list() {
         if (_mode == UiMode.SAVE_LIST) {
             if (_scrollable_saves.max == 0) {
@@ -163,12 +175,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
                 }
                 else {
                     FhSaveDisplayData save = FhApi.Saves.display_data[hovered];
-                    _fade.restart(
-                        COLOR_TRANS,
-                        COLOR_BLACK,
-                        null,
-                        () => execute(save.slot)
-                    );
+                    fade_out(() => execute(save.slot));
                 }
 
                 return;
@@ -210,12 +217,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
             if (_mode == UiMode.SET_SWAP)
                 change_mode(UiMode.SAVE_LIST);
             else
-                _fade.restart(
-                    COLOR_TRANS,
-                    COLOR_BLACK,
-                    null,
-                    () => FhApi.Saves.exit_cancel()
-                );
+                fade_out(() => FhApi.Saves.exit_cancel());
         }
     }
 
@@ -235,7 +237,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
             ? FhApi.Saves.get_slots_used() + 1 // Add one for New Save Data button
             : FhApi.Saves.display_data.Count;
 
-        _fade.restart(COLOR_BLACK, COLOR_TRANS);
+        _fade.restart(COLOR_BLACK, COLOR_TRANS, _fade_length);
     }
 
     private void post_close(EventArgs e) {
@@ -919,7 +921,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
             button_suv.p1 + shadow_offset,
             0x88000000
         );
-        
+
         draw.AddImage(
             plate,
             button_suv.p0,
@@ -1251,12 +1253,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
 
         // Handle input
         if (mouse_clicked(save_rect.scale_to_aspect(aspect_helper))) {
-            _fade.restart(
-                COLOR_TRANS,
-                COLOR_BLACK,
-                null,
-                () => execute(save.slot)
-            );
+            fade_out(() => execute(save.slot));
         }
     }
 

--- a/src/runtime/gui/save_ffx2.cs
+++ b/src/runtime/gui/save_ffx2.cs
@@ -171,7 +171,7 @@ public sealed class FhSaveUiX2 : FhSaveUi {
 
             if (_mode == UiMode.SAVE_LIST) {
                 if (is_saving && hovered == 0) {
-                    FhApi.Saves.save(0);
+                    fade_out(() => FhApi.Saves.save(0));
                 }
                 else {
                     FhSaveDisplayData save = FhApi.Saves.display_data[hovered];


### PR DESCRIPTION
Resolves #298.

Incidentally fixes an unrelated bug with the Timer/FadeHelper classes, where creating/restarting them with a length of zero would not run their action immediately.